### PR TITLE
Fix for object reference properties automatically being wrapped in an array.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -153,7 +153,8 @@ var getSchema = function(fullObject, objectName, definitions) {
     var propType = refDefinition[1];
     if (propType !== objectName) {
       // NOT circular reference
-      props[key] = [getSchema(definitions[propType]['properties'] ? definitions[propType]['properties'] : definitions[propType], propType, definitions)];
+      var schema = getSchema(definitions[propType]['properties'] ? definitions[propType]['properties'] : definitions[propType], propType, definitions);
+      props[key] = property['items'] || object.type === 'array' ? [schema] : schema;
     } else {
       // circular reference
       props[key] = {

--- a/test/index.js
+++ b/test/index.js
@@ -20,6 +20,7 @@ describe('swaggering-mongoose tests', function() {
 
   afterEach(function(done) {
     delete mongoose.models.Pet;
+    delete mongoose.models.Owner;
     delete mongoose.models.Address;
     delete mongoose.models.Error;
     delete mongoose.models.Person;
@@ -327,4 +328,25 @@ describe('swaggering-mongoose tests', function() {
     });
   });
 
+  it('should handle object reference properties based on reference type', function(done) {
+    var swagger = fs.readFileSync('./test/petstore3.json');
+    var Pet = swaggerMongoose.compile(swagger).models.Pet;
+    var myPet = new Pet({
+      id: 123,
+      name: 'Gizmo',
+      owner: { name: 'Chris' }
+    });
+    myPet.save(function(err) {
+      if (err) {
+        throw err;
+      }
+      Pet.findOne({
+        id: 123
+      }, function(err, data) {
+        assert(typeof data.owner === 'object', 'Type mismatch');
+        assert(data.owner.name === 'Chris', 'Name mismatch');
+        done();
+      });
+    });
+  });
 });

--- a/test/petstore3.json
+++ b/test/petstore3.json
@@ -147,6 +147,17 @@
             },
             "tag": {
               "type": "string"
+            },
+            "owner": {
+              "$ref": "#/definitions/Owner"
+            }
+          }
+        },
+        "Owner": {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string"
             }
           }
         }, 


### PR DESCRIPTION
Can be reproduced with the following schema:
`
"Human": 
{
"type": "object",
"properties": {
"father": {
"$ref": "#/definitions/Human"
}
}
`

The father object property will automatically be wrapped in an array. This is an undesired edge-case. Reference to how a similar library (swagger-mongoose) handles this (similar to this fix): https://github.com/simonguest/swagger-mongoose/blob/5a2b4af085ad38165d471f608547042977c7df6d/lib/index.js#L192